### PR TITLE
Move asViewStore methods to AbstractViewStore

### DIFF
--- a/Sources/Lasso/Store/Store.swift
+++ b/Sources/Lasso/Store/Store.swift
@@ -17,7 +17,7 @@
 
 import Foundation
 
-public protocol AbstractStore: StateObservable, ActionDispatchable, OutputObservable { }
+public protocol AbstractStore: AbstractViewStore, OutputObservable { }
 
 public protocol ConcreteStore: AbstractStore {
     init(with initialState: State)
@@ -131,88 +131,6 @@ extension LassoStore where Module: ScreenModule {
     
     public convenience init() {
         self.init(with: Module.defaultInitialState)
-    }
-    
-}
-
-extension AbstractStore {
-    
-    public typealias ActionMap<A> = (A) -> Action
-    public typealias StateMap<S> = (State) -> S
-    
-    /// Create a ViewStore with a ViewState that can be initialized from the Store's State,
-    /// using a ViewModule to define the relevant ViewState & ViewAction types.
-    ///
-    /// - Parameters:
-    ///   - viewModuleType: the ViewModule that defines the target ViewState
-    ///   - stateMap: a closure that converts the Store's State to the ViewState
-    /// - Returns: a new ViewStore
-    public func asViewStore<Module: ViewModule>(for viewModuleType: Module.Type,
-                                                stateMap: @escaping StateMap<Module.ViewState>) -> AnyViewStore<Module.ViewState, Module.ViewAction>
-        where Module.ViewAction == Action {
-            return asViewStore(stateMap: stateMap, actionMap: { $0 })
-    }
-    
-    /// Create a ViewStore using a subset of actions, with the Store's State type,
-    /// using a ViewModule to define the relevant ViewState & ViewAction types.
-    ///
-    /// - Parameters:
-    ///   - viewModuleType: the ViewModule that defines the target ViewAction
-    ///   - actionMap: a closure that maps the View's actions to the Store's actions
-    /// - Returns: a new ViewStore
-    public func asViewStore<Module: ViewModule>(for viewModuleType: Module.Type,
-                                                actionMap: @escaping ActionMap<Module.ViewAction>) -> AnyViewStore<Module.ViewState, Module.ViewAction>
-        where Module.ViewState == State {
-            return asViewStore(stateMap: { $0 }, actionMap: actionMap)
-    }
-    
-    /// Create a ViewStore using a subset of actions, with a ViewState that can be initialized from the Store's State,
-    /// using a ViewModule to define the relevant ViewState & ViewAction types.
-    ///
-    /// - Parameters:
-    ///   - viewModuleType: the ViewModule that defines the target ViewState and ViewAction
-    ///   - stateMap: a closure that converts the Store's State to the ViewState
-    ///   - actionMap: a closure that maps the View's actions to the Store's actions
-    /// - Returns: a new ViewStore
-    public func asViewStore<Module: ViewModule>(for viewModuleType: Module.Type,
-                                                stateMap: @escaping StateMap<Module.ViewState>,
-                                                actionMap: @escaping ActionMap<Module.ViewAction>) -> AnyViewStore<Module.ViewState, Module.ViewAction> {
-        return asViewStore(stateMap: stateMap, actionMap: actionMap)
-    }
-    
-    /// Create a ViewStore using the Store's State and Action types,
-    /// that provides access to just the dispatchAction and observeState methods.
-    ///
-    /// - Returns: a new ViewStore
-    public func asViewStore() -> AnyViewStore<State, Action> {
-        return asViewStore(stateMap: { $0 }, actionMap: { $0 })
-    }
-    
-    /// Create a ViewStore with a ViewState that can be initialized from the Store's State
-    ///
-    /// - Parameter stateMap: a closure that maps the View's actions to the Store's actions
-    /// - Returns: a new ViewStore
-    public func asViewStore<ViewState>(stateMap: @escaping StateMap<ViewState>) -> AnyViewStore<ViewState, Action> {
-        return asViewStore(stateMap: stateMap, actionMap: { $0 })
-    }
-    
-    /// Create a ViewStore using a subset of actions, with the Store's State type.
-    ///
-    /// - Parameter actionMap: a closure that maps the View's actions to the Store's actions
-    /// - Returns: a new ViewStore
-    public func asViewStore<ViewAction>(actionMap: @escaping ActionMap<ViewAction>) -> AnyViewStore<State, ViewAction> {
-        return asViewStore(stateMap: { $0 }, actionMap: actionMap)
-    }
-    
-    /// Create a ViewStore using a subset of actions, with a ViewState that can be initialized from the Store's State
-    ///
-    /// - Parameters:
-    ///   - actionMap: a closure that maps the View's actions to the Store's actions
-    ///   - stateMap: a closure that converts the Store's State to the ViewState
-    /// - Returns: a new ViewStore
-    public func asViewStore<ViewState, ViewAction>(stateMap: @escaping StateMap<ViewState>,
-                                                   actionMap: @escaping ActionMap<ViewAction>) -> AnyViewStore<ViewState, ViewAction> {
-        return AnyViewStore<ViewState, ViewAction>(self, stateMap: stateMap, actionMap: actionMap)
     }
     
 }

--- a/Sources/Lasso/Store/ViewStore.swift
+++ b/Sources/Lasso/Store/ViewStore.swift
@@ -30,7 +30,7 @@ public class AnyViewStore<ViewState, ViewAction>: AbstractViewStore {
     ///   - store: the concrete, source store
     ///   - stateMap: pure function; maps store state to view state
     ///   - actionMap: pure function; maps view action to store action
-    internal init<Store: AbstractStore>(_ store: Store, stateMap: @escaping (Store.State) -> ViewState, actionMap: @escaping (ViewAction) -> Store.Action) {
+    internal init<Store: AbstractViewStore>(_ store: Store, stateMap: @escaping (Store.State) -> ViewState, actionMap: @escaping (ViewAction) -> Store.Action) {
         self.binder = ValueBinder<ViewState>(stateMap(store.state))
         
         self._dispatchAction = { viewAction in
@@ -87,6 +87,88 @@ extension AnyViewStore where ViewState: Equatable {
     
     public func observeState(handler: @escaping (ViewState) -> Void) {
         observeState { _, newState in handler(newState) }
+    }
+    
+}
+
+extension AbstractViewStore {
+    
+    public typealias ActionMap<A> = (A) -> Action
+    public typealias StateMap<S> = (State) -> S
+    
+    /// Create a ViewStore with a ViewState that can be initialized from the Store's State,
+    /// using a ViewModule to define the relevant ViewState & ViewAction types.
+    ///
+    /// - Parameters:
+    ///   - viewModuleType: the ViewModule that defines the target ViewState
+    ///   - stateMap: a closure that converts the Store's State to the ViewState
+    /// - Returns: a new ViewStore
+    public func asViewStore<Module: ViewModule>(for viewModuleType: Module.Type,
+                                                stateMap: @escaping StateMap<Module.ViewState>) -> AnyViewStore<Module.ViewState, Module.ViewAction>
+        where Module.ViewAction == Action {
+            return asViewStore(stateMap: stateMap, actionMap: { $0 })
+    }
+    
+    /// Create a ViewStore using a subset of actions, with the Store's State type,
+    /// using a ViewModule to define the relevant ViewState & ViewAction types.
+    ///
+    /// - Parameters:
+    ///   - viewModuleType: the ViewModule that defines the target ViewAction
+    ///   - actionMap: a closure that maps the View's actions to the Store's actions
+    /// - Returns: a new ViewStore
+    public func asViewStore<Module: ViewModule>(for viewModuleType: Module.Type,
+                                                actionMap: @escaping ActionMap<Module.ViewAction>) -> AnyViewStore<Module.ViewState, Module.ViewAction>
+        where Module.ViewState == State {
+            return asViewStore(stateMap: { $0 }, actionMap: actionMap)
+    }
+    
+    /// Create a ViewStore using a subset of actions, with a ViewState that can be initialized from the Store's State,
+    /// using a ViewModule to define the relevant ViewState & ViewAction types.
+    ///
+    /// - Parameters:
+    ///   - viewModuleType: the ViewModule that defines the target ViewState and ViewAction
+    ///   - stateMap: a closure that converts the Store's State to the ViewState
+    ///   - actionMap: a closure that maps the View's actions to the Store's actions
+    /// - Returns: a new ViewStore
+    public func asViewStore<Module: ViewModule>(for viewModuleType: Module.Type,
+                                                stateMap: @escaping StateMap<Module.ViewState>,
+                                                actionMap: @escaping ActionMap<Module.ViewAction>) -> AnyViewStore<Module.ViewState, Module.ViewAction> {
+        return asViewStore(stateMap: stateMap, actionMap: actionMap)
+    }
+    
+    /// Create a ViewStore using the Store's State and Action types,
+    /// that provides access to just the dispatchAction and observeState methods.
+    ///
+    /// - Returns: a new ViewStore
+    public func asViewStore() -> AnyViewStore<State, Action> {
+        return asViewStore(stateMap: { $0 }, actionMap: { $0 })
+    }
+    
+    /// Create a ViewStore with a ViewState that can be initialized from the Store's State
+    ///
+    /// - Parameter stateMap: a closure that maps the View's actions to the Store's actions
+    /// - Returns: a new ViewStore
+    public func asViewStore<ViewState>(stateMap: @escaping StateMap<ViewState>) -> AnyViewStore<ViewState, Action> {
+        return asViewStore(stateMap: stateMap, actionMap: { $0 })
+    }
+    
+    /// Create a ViewStore using a subset of actions, with the Store's State type.
+    ///
+    /// - Parameter actionMap: a closure that maps the View's actions to the Store's actions
+    /// - Returns: a new ViewStore
+    public func asViewStore<ViewAction>(actionMap: @escaping ActionMap<ViewAction>) -> AnyViewStore<State, ViewAction> {
+        return asViewStore(stateMap: { $0 }, actionMap: actionMap)
+    }
+    
+    /// Create a ViewStore using a subset of actions, with a ViewState that can be initialized from the Store's State
+    ///
+    /// - Parameters:
+    ///   - actionMap: a closure that maps the View's actions to the Store's actions
+    ///   - stateMap: a closure that converts the Store's State to the ViewState
+    /// - Returns: a new ViewStore
+    public func asViewStore<ViewState, ViewAction>(stateMap: @escaping StateMap<ViewState>,
+                                                   actionMap: @escaping ActionMap<ViewAction>) -> AnyViewStore<ViewState, ViewAction> {
+        return AnyViewStore<ViewState, ViewAction>(self, stateMap: stateMap, actionMap: actionMap)
     }
     
 }


### PR DESCRIPTION

## Description

Moves all of the `asViewStore` methods out of `AbstractStore` and into an extension on `AbstractViewStore`.  Having these functions operable on `AbstractStore` unnecessarily limits their scope.

`asViewStore` only deals in State and Action - in both the _from_ store and the _to_ store.  Moving these functions to a context where that's all that exists frees programmers to map one _view_ store to another.

This is a non-breaking change, backwards compatible with existing code.