### PR TITLE
Add bind convenience for UIBarButtonItem

### DIFF
--- a/Example/Lasso/Samples/UIKitBindings.swift
+++ b/Example/Lasso/Samples/UIKitBindings.swift
@@ -19,6 +19,8 @@ import UIKit
 import WWLayout
 import Lasso
 
+// MARK: - Module
+
 enum UIKitBindingsScreenModule: ScreenModule {
     
     static var defaultInitialState: State { return State() }
@@ -36,6 +38,7 @@ enum UIKitBindingsScreenModule: ScreenModule {
         case didChangeAmount(Double)
         case didEditText(String)
         case didChangeDate(Date)
+        case didTapBarButton
         case didTapButton
     }
     
@@ -43,6 +46,8 @@ enum UIKitBindingsScreenModule: ScreenModule {
         var lastAction: String = ""
     }
 }
+
+// MARK: - Store
 
 class UIKitBindingsStore: LassoStore<UIKitBindingsScreenModule> {
     
@@ -53,6 +58,8 @@ class UIKitBindingsStore: LassoStore<UIKitBindingsScreenModule> {
     }
     
 }
+
+// MARK: - View
 
 class UIKitBindingsViewController: UIViewController, LassoView {
     
@@ -68,6 +75,9 @@ class UIKitBindingsViewController: UIViewController, LassoView {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .background
+        
+        let barButton = UIBarButtonItem(barButtonSystemItem: .action)
+        navigationItem.rightBarButtonItem = barButton
         
         let stack = UIStackView()
         stack.axis = .vertical
@@ -124,6 +134,7 @@ class UIKitBindingsViewController: UIViewController, LassoView {
         
         // bind .touchUpInside directly to a dispatched action on the store:
         button.bind(to: store, action: .didTapButton)
+        barButton.bind(to: store, action: .didTapBarButton)
         
         store.observeState(\.lastAction) { [weak label] lastAction in
             label?.text = lastAction

--- a/Sources/Lasso/Types/ActionDispatchable+Bindings.swift
+++ b/Sources/Lasso/Types/ActionDispatchable+Bindings.swift
@@ -165,6 +165,52 @@ extension ControlActionBindable {
     
 }
 
+// MARK: - Bar button item action binding
+
+extension UIBarButtonItem {
+    
+    public convenience init(barButtonSystemItem systemItem: UIBarButtonItem.SystemItem) {
+        self.init(barButtonSystemItem: systemItem, target: nil, action: nil)
+    }
+    
+    public convenience init(image: UIImage?, style: UIBarButtonItem.Style = .plain) {
+        self.init(image: image, style: style, target: nil, action: nil)
+    }
+    
+    public convenience init(image: UIImage?, landscapeImagePhone: UIImage?, style: UIBarButtonItem.Style = .plain) {
+        self.init(image: image, landscapeImagePhone: landscapeImagePhone, style: style, target: nil, action: nil)
+    }
+    
+    public convenience init(title: String?, style: UIBarButtonItem.Style = .plain) {
+        self.init(title: title, style: style, target: nil, action: nil)
+    }
+    
+    /// Bind a bar button item's action to an ActionDispatchable (a.k.a. Store).
+    ///
+    /// - Parameters:
+    ///   - target: The ActionDispatchable to receive the Action.
+    ///   - toAction: A Store.Action to send to the target via its `dispatchAction` method.
+    public func bind<Target: ActionDispatchable>(to target: Target, action: Target.Action) {
+        bind(to: target) { _ in return action }
+    }
+    
+    /// Bind a UIBarButtonItem event to an ActionDispatchable where the Action is a function of the item at the time of invocation.
+    ///
+    /// - Parameters:
+    ///   - target: The ActionDispatchable to receive the Action.
+    ///   - mapping: A function that maps the gesture recognizer's current state to an ActionDispatchable.Action to be dispatched to the target.
+    ///   - sender: The UIGestureRecognizer triggering the action
+    public func bind<Target: ActionDispatchable>(to target: Target, mapping: @escaping (_ sender: UIBarButtonItem) -> Target.Action) {
+        let eventHandler = EventHandler { [weak self, weak target] in
+            self.map { target?.dispatchAction(mapping($0)) }
+        }
+        self.target = eventHandler
+        self.action = #selector(eventHandler.execute)
+        holdReference(to: eventHandler)
+    }
+    
+}
+
 // MARK: - Gesture recognizer action binding
 
 extension UIGestureRecognizer {

--- a/Sources/Lasso/Types/ActionDispatchable+Bindings.swift
+++ b/Sources/Lasso/Types/ActionDispatchable+Bindings.swift
@@ -198,8 +198,8 @@ extension UIBarButtonItem {
     ///
     /// - Parameters:
     ///   - target: The ActionDispatchable to receive the Action.
-    ///   - mapping: A function that maps the gesture recognizer's current state to an ActionDispatchable.Action to be dispatched to the target.
-    ///   - sender: The UIGestureRecognizer triggering the action
+    ///   - mapping: A function that maps the button tap to an ActionDispatchable.Action to be dispatched to the target.
+    ///   - sender: The UIBarButtonItem triggering the action
     public func bind<Target: ActionDispatchable>(to target: Target, mapping: @escaping (_ sender: UIBarButtonItem) -> Target.Action) {
         let eventHandler = EventHandler { [weak self, weak target] in
             self.map { target?.dispatchAction(mapping($0)) }


### PR DESCRIPTION
Adds a `bind` convenience - like what is available for `UIButton` objects - for `UIBarButtonItem` instances:

```swift
let button = UIBarButtonItem(barButtonSystemItem: .action)
button.bind(to: store, action: .didTapActionButton)
```