### PR TITLE
Fix LassoTestUtilities dependencies for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,19 +10,25 @@ let package = Package(
     products: [
         .library(
             name: "Lasso",
-            targets: ["Lasso"]),
+            targets: ["Lasso"]
+        ),
         .library(
             name: "LassoTestUtilities",
-            targets: ["LassoTestUtilities"])
+            targets: ["LassoTestUtilities"]
+        )
     ],
     dependencies: [
     ],
     targets: [
         .target(
             name: "Lasso",
-            dependencies: []),
+            dependencies: []
+        ),
         .target(
             name: "LassoTestUtilities",
-            dependencies: [])
+            dependencies: [
+                .target(name: "Lasso")
+            ]
+        )
     ]
 )


### PR DESCRIPTION
## Describe your changes

This fixes an issue in `Package.swift` where `LassoTestUtilities` didn't properly declare the `Lasso` target as a dependency.
