### PR TITLE
Turn off UIView animations when possible

### DIFF
--- a/Example/Lasso/AppDelegate.swift
+++ b/Example/Lasso/AppDelegate.swift
@@ -29,7 +29,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.window = window
         
         if Testing.active {
+            // If the app is the host for unit tests, then skip the normal view controller setup:
             window.rootViewController = UIViewController()
+            
+            // Also turn off standard view animations to help speed up Flow unit tests:
+            UIView.setAnimationsEnabled(false)
         }
         else {
             SampleCatalogFlow().start(with: root(of: window).withNavigationEmbedding())

--- a/Example/LassoTestUtilities_Tests/ModalTestingTests+AnyModalPresentationStyle.swift
+++ b/Example/LassoTestUtilities_Tests/ModalTestingTests+AnyModalPresentationStyle.swift
@@ -20,6 +20,11 @@ import XCTest
 
 class ModalTestingTestsAnyModalPresentationStyle: XCTestCase {
     
+    override class func setUp() {
+        super.setUp()
+        UIView.setAnimationsEnabled(true)
+    }
+    
     private func testSupportedStyles(_ test: (UIModalPresentationStyle) throws -> Void) throws {
         let styles: [UIModalPresentationStyle] = [.pageSheet, .fullScreen]
         try styles.forEach(test)

--- a/Example/LassoTestUtilities_Tests/ModalTestingTests+FullScreen.swift
+++ b/Example/LassoTestUtilities_Tests/ModalTestingTests+FullScreen.swift
@@ -20,6 +20,11 @@ import XCTest
 
 class ModalTestingTestsFullScreen: XCTestCase {
     
+    override class func setUp() {
+        super.setUp()
+        UIView.setAnimationsEnabled(true)
+    }
+    
     // MARK: - Success
 
     func test_Animated_Presentation() throws {

--- a/Example/LassoTestUtilities_Tests/ModalTestingTests+SystemBehavior.swift
+++ b/Example/LassoTestUtilities_Tests/ModalTestingTests+SystemBehavior.swift
@@ -20,6 +20,11 @@ import XCTest
 
 class ModalTestingTestsSystemBehavior: XCTestCase {
     
+    override class func setUp() {
+        super.setUp()
+        UIView.setAnimationsEnabled(true)
+    }
+    
     private func testSupportedStyles(_ test: (UIModalPresentationStyle) throws -> Void) throws {
         let styles: [UIModalPresentationStyle] = [.pageSheet, .fullScreen]
         try styles.forEach(test)

--- a/Example/LassoTestUtilities_Tests/NavigationTestingTests.swift
+++ b/Example/LassoTestUtilities_Tests/NavigationTestingTests.swift
@@ -23,6 +23,11 @@ import UIKit
 
 class NavigationTestingTests: XCTestCase {
     
+    override class func setUp() {
+        super.setUp()
+        UIView.setAnimationsEnabled(true)
+    }
+    
     // MARK: - Success
     
     // assertPushed


### PR DESCRIPTION
## Describe your changes

This turns off standard UIView animations in the example app, when it is the host for unit tests.  This has only a minimal effect on the test execution time in the example app, but serves as a good example for apps that use Lasso.

Note that the UIView animations are explicitly enabled for the unit tests of the test utilities, so as not to interfere with their setup.
