### PR TITLE
Add SwiftUI, approach #2

### DIFF
--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI.xcodeproj/project.pbxproj
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI.xcodeproj/project.pbxproj
@@ -1,0 +1,681 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B0058819260B575300C7462A /* Color+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0058818260B575300C7462A /* Color+Style.swift */; };
+		B005881F260B589200C7462A /* ButtonStyle+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = B005881E260B589200C7462A /* ButtonStyle+App.swift */; };
+		B0058A8E260CA40F00C7462A /* SimpleCounterStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0058A8D260CA40F00C7462A /* SimpleCounterStore.swift */; };
+		B0058A94260CA41800C7462A /* SimpleCounterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0058A93260CA41800C7462A /* SimpleCounterView.swift */; };
+		B055D72B260A6AFF0077DA48 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B055D72A260A6AFF0077DA48 /* AppDelegate.swift */; };
+		B055D72D260A6AFF0077DA48 /* AppCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B055D72C260A6AFF0077DA48 /* AppCatalogView.swift */; };
+		B055D72F260A6B000077DA48 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B055D72E260A6B000077DA48 /* Assets.xcassets */; };
+		B055D732260A6B000077DA48 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B055D731260A6B000077DA48 /* Preview Assets.xcassets */; };
+		B055D73D260A6B000077DA48 /* Lasso_SwiftUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B055D73C260A6B000077DA48 /* Lasso_SwiftUITests.swift */; };
+		B055D796260A6DDF0077DA48 /* AppCatalogScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B055D795260A6DDF0077DA48 /* AppCatalogScreen.swift */; };
+		B055D79E260A72C60077DA48 /* AppCatalogFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B055D79D260A72C60077DA48 /* AppCatalogFlow.swift */; };
+		B055D7A3260A73810077DA48 /* Lasso in Frameworks */ = {isa = PBXBuildFile; productRef = B055D7A2260A73810077DA48 /* Lasso */; };
+		B055D7AA260A79350077DA48 /* SelfIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B055D7A9260A79350077DA48 /* SelfIdentifiable.swift */; };
+		B05E5360260E20C30086A6D8 /* TextFieldStyle+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05E535F260E20C30086A6D8 /* TextFieldStyle+App.swift */; };
+		B05E5364260E34B00086A6D8 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05E5363260E34B00086A6D8 /* ActivityIndicator.swift */; };
+		B05E537A260E58B90086A6D8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B05E5379260E58B90086A6D8 /* LaunchScreen.storyboard */; };
+		B08952CC260B485600E2FC98 /* EdgeInsets+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08952CB260B485600E2FC98 /* EdgeInsets+Helpers.swift */; };
+		B08952D3260B4E9500E2FC98 /* NavigationRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08952D2260B4E9500E2FC98 /* NavigationRow.swift */; };
+		B08952DB260B51B500E2FC98 /* SimpleCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08952DA260B51B500E2FC98 /* SimpleCounter.swift */; };
+		B0B23390260CAC1900F1EB2F /* String+CamelCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B2338F260CAC1900F1EB2F /* String+CamelCase.swift */; };
+		B0B23571260D035300F1EB2F /* WelcomeOnboardingFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B23570260D035300F1EB2F /* WelcomeOnboardingFlow.swift */; };
+		B0B23577260D03C100F1EB2F /* WelcomeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B23576260D03C100F1EB2F /* WelcomeMessage.swift */; };
+		B0B2357B260D04A500F1EB2F /* WelcomeMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B2357A260D04A500F1EB2F /* WelcomeMessageView.swift */; };
+		B0B23587260E14C200F1EB2F /* Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B23586260E14C200F1EB2F /* Login.swift */; };
+		B0B2358D260E150A00F1EB2F /* LoginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B2358C260E150A00F1EB2F /* LoginStore.swift */; };
+		B0B23591260E155F00F1EB2F /* LoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B23590260E155F00F1EB2F /* LoginService.swift */; };
+		B0B23595260E15BB00F1EB2F /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B23594260E15BB00F1EB2F /* LoginView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		B055D739260A6B000077DA48 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B055D71F260A6AFF0077DA48 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B055D726260A6AFF0077DA48;
+			remoteInfo = "Lasso-SwiftUI";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		B0058818260B575300C7462A /* Color+Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Style.swift"; sourceTree = "<group>"; };
+		B005881E260B589200C7462A /* ButtonStyle+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ButtonStyle+App.swift"; sourceTree = "<group>"; };
+		B0058A8D260CA40F00C7462A /* SimpleCounterStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleCounterStore.swift; sourceTree = "<group>"; };
+		B0058A93260CA41800C7462A /* SimpleCounterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleCounterView.swift; sourceTree = "<group>"; };
+		B055D727260A6AFF0077DA48 /* Lasso-SwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Lasso-SwiftUI.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B055D72A260A6AFF0077DA48 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		B055D72C260A6AFF0077DA48 /* AppCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCatalogView.swift; sourceTree = "<group>"; };
+		B055D72E260A6B000077DA48 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B055D731260A6B000077DA48 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		B055D733260A6B000077DA48 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B055D738260A6B000077DA48 /* Lasso-SwiftUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Lasso-SwiftUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B055D73C260A6B000077DA48 /* Lasso_SwiftUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lasso_SwiftUITests.swift; sourceTree = "<group>"; };
+		B055D73E260A6B000077DA48 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B055D78A260A6D700077DA48 /* lasso */ = {isa = PBXFileReference; lastKnownFileType = folder; name = lasso; path = ../..; sourceTree = "<group>"; };
+		B055D795260A6DDF0077DA48 /* AppCatalogScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCatalogScreen.swift; sourceTree = "<group>"; };
+		B055D79D260A72C60077DA48 /* AppCatalogFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCatalogFlow.swift; sourceTree = "<group>"; };
+		B055D7A9260A79350077DA48 /* SelfIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfIdentifiable.swift; sourceTree = "<group>"; };
+		B05E535F260E20C30086A6D8 /* TextFieldStyle+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextFieldStyle+App.swift"; sourceTree = "<group>"; };
+		B05E5363260E34B00086A6D8 /* ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
+		B05E5379260E58B90086A6D8 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		B08952CB260B485600E2FC98 /* EdgeInsets+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EdgeInsets+Helpers.swift"; sourceTree = "<group>"; };
+		B08952D2260B4E9500E2FC98 /* NavigationRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRow.swift; sourceTree = "<group>"; };
+		B08952DA260B51B500E2FC98 /* SimpleCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleCounter.swift; sourceTree = "<group>"; };
+		B0B2338F260CAC1900F1EB2F /* String+CamelCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+CamelCase.swift"; sourceTree = "<group>"; };
+		B0B23570260D035300F1EB2F /* WelcomeOnboardingFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeOnboardingFlow.swift; sourceTree = "<group>"; };
+		B0B23576260D03C100F1EB2F /* WelcomeMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessage.swift; sourceTree = "<group>"; };
+		B0B2357A260D04A500F1EB2F /* WelcomeMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessageView.swift; sourceTree = "<group>"; };
+		B0B23586260E14C200F1EB2F /* Login.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Login.swift; sourceTree = "<group>"; };
+		B0B2358C260E150A00F1EB2F /* LoginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginStore.swift; sourceTree = "<group>"; };
+		B0B23590260E155F00F1EB2F /* LoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginService.swift; sourceTree = "<group>"; };
+		B0B23594260E15BB00F1EB2F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B055D724260A6AFF0077DA48 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B055D7A3260A73810077DA48 /* Lasso in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B055D735260A6B000077DA48 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		B0058817260B573300C7462A /* Style */ = {
+			isa = PBXGroup;
+			children = (
+				B0058818260B575300C7462A /* Color+Style.swift */,
+				B005881E260B589200C7462A /* ButtonStyle+App.swift */,
+				B05E535F260E20C30086A6D8 /* TextFieldStyle+App.swift */,
+			);
+			path = Style;
+			sourceTree = "<group>";
+		};
+		B0058A8A260CA3F900C7462A /* SimpleCounter */ = {
+			isa = PBXGroup;
+			children = (
+				B08952DA260B51B500E2FC98 /* SimpleCounter.swift */,
+				B0058A8D260CA40F00C7462A /* SimpleCounterStore.swift */,
+				B0058A93260CA41800C7462A /* SimpleCounterView.swift */,
+			);
+			path = SimpleCounter;
+			sourceTree = "<group>";
+		};
+		B0058A9B260CA82400C7462A /* AppCatalogScreen */ = {
+			isa = PBXGroup;
+			children = (
+				B055D795260A6DDF0077DA48 /* AppCatalogScreen.swift */,
+				B055D72C260A6AFF0077DA48 /* AppCatalogView.swift */,
+			);
+			path = AppCatalogScreen;
+			sourceTree = "<group>";
+		};
+		B055D71E260A6AFF0077DA48 = {
+			isa = PBXGroup;
+			children = (
+				B055D78A260A6D700077DA48 /* lasso */,
+				B055D729260A6AFF0077DA48 /* Lasso-SwiftUI */,
+				B055D73B260A6B000077DA48 /* Lasso-SwiftUITests */,
+				B055D728260A6AFF0077DA48 /* Products */,
+				B055D7A1260A73810077DA48 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		B055D728260A6AFF0077DA48 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B055D727260A6AFF0077DA48 /* Lasso-SwiftUI.app */,
+				B055D738260A6B000077DA48 /* Lasso-SwiftUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B055D729260A6AFF0077DA48 /* Lasso-SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				B055D72A260A6AFF0077DA48 /* AppDelegate.swift */,
+				B055D787260A6CDF0077DA48 /* AppCatalog */,
+				B055D784260A6CB40077DA48 /* Samples */,
+				B08952D1260B4E8500E2FC98 /* Components */,
+				B0058817260B573300C7462A /* Style */,
+				B055D7A8260A79240077DA48 /* Utilities */,
+				B055D72E260A6B000077DA48 /* Assets.xcassets */,
+				B055D733260A6B000077DA48 /* Info.plist */,
+				B05E5379260E58B90086A6D8 /* LaunchScreen.storyboard */,
+				B055D730260A6B000077DA48 /* Preview Content */,
+			);
+			path = "Lasso-SwiftUI";
+			sourceTree = "<group>";
+		};
+		B055D730260A6B000077DA48 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				B055D731260A6B000077DA48 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		B055D73B260A6B000077DA48 /* Lasso-SwiftUITests */ = {
+			isa = PBXGroup;
+			children = (
+				B055D73C260A6B000077DA48 /* Lasso_SwiftUITests.swift */,
+				B055D73E260A6B000077DA48 /* Info.plist */,
+			);
+			path = "Lasso-SwiftUITests";
+			sourceTree = "<group>";
+		};
+		B055D784260A6CB40077DA48 /* Samples */ = {
+			isa = PBXGroup;
+			children = (
+				B055D785260A6CC10077DA48 /* Screens */,
+				B055D786260A6CC70077DA48 /* Flows */,
+			);
+			path = Samples;
+			sourceTree = "<group>";
+		};
+		B055D785260A6CC10077DA48 /* Screens */ = {
+			isa = PBXGroup;
+			children = (
+				B0058A8A260CA3F900C7462A /* SimpleCounter */,
+				B0B23585260E14B300F1EB2F /* Login */,
+			);
+			path = Screens;
+			sourceTree = "<group>";
+		};
+		B055D786260A6CC70077DA48 /* Flows */ = {
+			isa = PBXGroup;
+			children = (
+				B0B2356F260D033F00F1EB2F /* WelcomeOnboarding */,
+			);
+			path = Flows;
+			sourceTree = "<group>";
+		};
+		B055D787260A6CDF0077DA48 /* AppCatalog */ = {
+			isa = PBXGroup;
+			children = (
+				B055D79D260A72C60077DA48 /* AppCatalogFlow.swift */,
+				B0058A9B260CA82400C7462A /* AppCatalogScreen */,
+			);
+			path = AppCatalog;
+			sourceTree = "<group>";
+		};
+		B055D7A1260A73810077DA48 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		B055D7A8260A79240077DA48 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				B055D7A9260A79350077DA48 /* SelfIdentifiable.swift */,
+				B08952CB260B485600E2FC98 /* EdgeInsets+Helpers.swift */,
+				B0B2338F260CAC1900F1EB2F /* String+CamelCase.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		B08952D1260B4E8500E2FC98 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				B08952D2260B4E9500E2FC98 /* NavigationRow.swift */,
+				B05E5363260E34B00086A6D8 /* ActivityIndicator.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		B0B2356F260D033F00F1EB2F /* WelcomeOnboarding */ = {
+			isa = PBXGroup;
+			children = (
+				B0B23570260D035300F1EB2F /* WelcomeOnboardingFlow.swift */,
+				B0B23576260D03C100F1EB2F /* WelcomeMessage.swift */,
+				B0B2357A260D04A500F1EB2F /* WelcomeMessageView.swift */,
+			);
+			path = WelcomeOnboarding;
+			sourceTree = "<group>";
+		};
+		B0B23585260E14B300F1EB2F /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				B0B23586260E14C200F1EB2F /* Login.swift */,
+				B0B2358C260E150A00F1EB2F /* LoginStore.swift */,
+				B0B23590260E155F00F1EB2F /* LoginService.swift */,
+				B0B23594260E15BB00F1EB2F /* LoginView.swift */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		B055D726260A6AFF0077DA48 /* Lasso-SwiftUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B055D74C260A6B000077DA48 /* Build configuration list for PBXNativeTarget "Lasso-SwiftUI" */;
+			buildPhases = (
+				B055D723260A6AFF0077DA48 /* Sources */,
+				B055D724260A6AFF0077DA48 /* Frameworks */,
+				B055D725260A6AFF0077DA48 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B055D78E260A6D840077DA48 /* PBXTargetDependency */,
+			);
+			name = "Lasso-SwiftUI";
+			packageProductDependencies = (
+				B055D7A2260A73810077DA48 /* Lasso */,
+			);
+			productName = "Lasso-SwiftUI";
+			productReference = B055D727260A6AFF0077DA48 /* Lasso-SwiftUI.app */;
+			productType = "com.apple.product-type.application";
+		};
+		B055D737260A6B000077DA48 /* Lasso-SwiftUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B055D74F260A6B000077DA48 /* Build configuration list for PBXNativeTarget "Lasso-SwiftUITests" */;
+			buildPhases = (
+				B055D734260A6B000077DA48 /* Sources */,
+				B055D735260A6B000077DA48 /* Frameworks */,
+				B055D736260A6B000077DA48 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B055D790260A6D8B0077DA48 /* PBXTargetDependency */,
+				B055D792260A6D8B0077DA48 /* PBXTargetDependency */,
+				B055D73A260A6B000077DA48 /* PBXTargetDependency */,
+			);
+			name = "Lasso-SwiftUITests";
+			productName = "Lasso-SwiftUITests";
+			productReference = B055D738260A6B000077DA48 /* Lasso-SwiftUITests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B055D71F260A6AFF0077DA48 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					B055D726260A6AFF0077DA48 = {
+						CreatedOnToolsVersion = 12.4;
+					};
+					B055D737260A6B000077DA48 = {
+						CreatedOnToolsVersion = 12.4;
+						TestTargetID = B055D726260A6AFF0077DA48;
+					};
+				};
+			};
+			buildConfigurationList = B055D722260A6AFF0077DA48 /* Build configuration list for PBXProject "Lasso-SwiftUI" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = B055D71E260A6AFF0077DA48;
+			productRefGroup = B055D728260A6AFF0077DA48 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B055D726260A6AFF0077DA48 /* Lasso-SwiftUI */,
+				B055D737260A6B000077DA48 /* Lasso-SwiftUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		B055D725260A6AFF0077DA48 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B05E537A260E58B90086A6D8 /* LaunchScreen.storyboard in Resources */,
+				B055D732260A6B000077DA48 /* Preview Assets.xcassets in Resources */,
+				B055D72F260A6B000077DA48 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B055D736260A6B000077DA48 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		B055D723260A6AFF0077DA48 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B0B23591260E155F00F1EB2F /* LoginService.swift in Sources */,
+				B055D72D260A6AFF0077DA48 /* AppCatalogView.swift in Sources */,
+				B0B23587260E14C200F1EB2F /* Login.swift in Sources */,
+				B08952D3260B4E9500E2FC98 /* NavigationRow.swift in Sources */,
+				B055D72B260A6AFF0077DA48 /* AppDelegate.swift in Sources */,
+				B0B23577260D03C100F1EB2F /* WelcomeMessage.swift in Sources */,
+				B0B2358D260E150A00F1EB2F /* LoginStore.swift in Sources */,
+				B08952CC260B485600E2FC98 /* EdgeInsets+Helpers.swift in Sources */,
+				B055D796260A6DDF0077DA48 /* AppCatalogScreen.swift in Sources */,
+				B005881F260B589200C7462A /* ButtonStyle+App.swift in Sources */,
+				B055D7AA260A79350077DA48 /* SelfIdentifiable.swift in Sources */,
+				B0B23390260CAC1900F1EB2F /* String+CamelCase.swift in Sources */,
+				B0058A94260CA41800C7462A /* SimpleCounterView.swift in Sources */,
+				B08952DB260B51B500E2FC98 /* SimpleCounter.swift in Sources */,
+				B0058A8E260CA40F00C7462A /* SimpleCounterStore.swift in Sources */,
+				B05E5360260E20C30086A6D8 /* TextFieldStyle+App.swift in Sources */,
+				B05E5364260E34B00086A6D8 /* ActivityIndicator.swift in Sources */,
+				B0B23571260D035300F1EB2F /* WelcomeOnboardingFlow.swift in Sources */,
+				B055D79E260A72C60077DA48 /* AppCatalogFlow.swift in Sources */,
+				B0058819260B575300C7462A /* Color+Style.swift in Sources */,
+				B0B23595260E15BB00F1EB2F /* LoginView.swift in Sources */,
+				B0B2357B260D04A500F1EB2F /* WelcomeMessageView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B055D734260A6B000077DA48 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B055D73D260A6B000077DA48 /* Lasso_SwiftUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		B055D73A260A6B000077DA48 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B055D726260A6AFF0077DA48 /* Lasso-SwiftUI */;
+			targetProxy = B055D739260A6B000077DA48 /* PBXContainerItemProxy */;
+		};
+		B055D78E260A6D840077DA48 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = B055D78D260A6D840077DA48 /* Lasso */;
+		};
+		B055D790260A6D8B0077DA48 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = B055D78F260A6D8B0077DA48 /* Lasso */;
+		};
+		B055D792260A6D8B0077DA48 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = B055D791260A6D8B0077DA48 /* LassoTestUtilities */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		B055D74A260A6B000077DA48 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		B055D74B260A6B000077DA48 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		B055D74D260A6B000077DA48 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"Lasso-SwiftUI/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "Lasso-SwiftUI/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ww.Lasso-SwiftUI";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		B055D74E260A6B000077DA48 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"Lasso-SwiftUI/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "Lasso-SwiftUI/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ww.Lasso-SwiftUI";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+		B055D750260A6B000077DA48 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Lasso-SwiftUITests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ww.Lasso-SwiftUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Lasso-SwiftUI.app/Lasso-SwiftUI";
+			};
+			name = Debug;
+		};
+		B055D751260A6B000077DA48 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Lasso-SwiftUITests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ww.Lasso-SwiftUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Lasso-SwiftUI.app/Lasso-SwiftUI";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		B055D722260A6AFF0077DA48 /* Build configuration list for PBXProject "Lasso-SwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B055D74A260A6B000077DA48 /* Debug */,
+				B055D74B260A6B000077DA48 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B055D74C260A6B000077DA48 /* Build configuration list for PBXNativeTarget "Lasso-SwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B055D74D260A6B000077DA48 /* Debug */,
+				B055D74E260A6B000077DA48 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B055D74F260A6B000077DA48 /* Build configuration list for PBXNativeTarget "Lasso-SwiftUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B055D750260A6B000077DA48 /* Debug */,
+				B055D751260A6B000077DA48 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		B055D78D260A6D840077DA48 /* Lasso */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Lasso;
+		};
+		B055D78F260A6D8B0077DA48 /* Lasso */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Lasso;
+		};
+		B055D791260A6D8B0077DA48 /* LassoTestUtilities */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LassoTestUtilities;
+		};
+		B055D7A2260A73810077DA48 /* Lasso */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Lasso;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = B055D71F260A6AFF0077DA48 /* Project object */;
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string>
+// ==----------------------------------------------------------------------== //
+//
+//  ___FILENAME___
+//
+//  Created by ___FULLUSERNAME___ on ___DATE___
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-___YEAR___ WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//</string>
+</dict>
+</plist>

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI.xcodeproj/xcshareddata/xcschemes/Lasso-SwiftUI.xcscheme
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI.xcodeproj/xcshareddata/xcschemes/Lasso-SwiftUI.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B055D726260A6AFF0077DA48"
+               BuildableName = "Lasso-SwiftUI.app"
+               BlueprintName = "Lasso-SwiftUI"
+               ReferencedContainer = "container:Lasso-SwiftUI.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B055D737260A6B000077DA48"
+               BuildableName = "Lasso-SwiftUITests.xctest"
+               BlueprintName = "Lasso-SwiftUITests"
+               ReferencedContainer = "container:Lasso-SwiftUI.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B055D726260A6AFF0077DA48"
+            BuildableName = "Lasso-SwiftUI.app"
+            BlueprintName = "Lasso-SwiftUI"
+            ReferencedContainer = "container:Lasso-SwiftUI.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B055D726260A6AFF0077DA48"
+            BuildableName = "Lasso-SwiftUI.app"
+            BlueprintName = "Lasso-SwiftUI"
+            ReferencedContainer = "container:Lasso-SwiftUI.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/AppCatalog/AppCatalogFlow.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/AppCatalog/AppCatalogFlow.swift
@@ -1,0 +1,50 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  AppCatalogFlow.swift
+//
+//  Created by Steven Grosmark on 03/23/2021.
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import UIKit
+import Lasso
+
+final class AppCatalogFlow: Flow<NoOutputNavigationFlow> {
+    
+    override func createInitialController() -> UIViewController {
+        AppCatalogScreen
+            .createScreen()
+            .observeOutput { [weak self] in self?.handleOutput($0) }
+            .controller
+    }
+    
+    private func handleOutput(_ output: AppCatalogScreen.Output) {
+        switch output {
+        
+        case .simpleCounter:
+            SimpleCounter
+                .createScreen()
+                .place(with: nextPushedInFlow)
+            
+        case .login:
+            Login
+                .createScreen()
+                .observeOutput { [weak self] _ in self?.unwind() }
+                .place(with: nextPushedInFlow)
+            
+        case .welcome:
+            WelcomeOnboardingFlow()
+                .observeOutput { [weak self] _ in self?.unwind() }
+                .start(with: nextPresentedInFlow?.withDismissibleNavigationEmbedding())
+        }
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/AppCatalog/AppCatalogScreen/AppCatalogScreen.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/AppCatalog/AppCatalogScreen/AppCatalogScreen.swift
@@ -1,0 +1,62 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  AppCatalogScreen.swift
+//
+//  Created by Steven Grosmark on 03/23/2021.
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import UIKit
+import SwiftUI
+import Lasso
+
+enum AppCatalogScreen: ScreenModule {
+    
+    struct State: Equatable {
+        let title: String
+        let sections: [Section]
+    }
+    
+    enum Section: SelfIdentifiable, TitleConvertible {
+        
+        case screens
+        case flows
+        
+        var items: [Item] {
+            switch self {
+            case .screens: return [.simpleCounter, .login]
+            case .flows: return [.welcome]
+            }
+        }
+        
+        enum Item: SelfIdentifiable, TitleConvertible {
+            case simpleCounter, login
+            case welcome
+        }
+    }
+    
+    typealias Action = Section.Item
+    typealias Output = Action
+    
+    static func createScreen(with store: AppCatalogStore) -> Screen {
+        Screen(store, AppCatalogView(store: store.asViewStore()))
+    }
+    
+    static var defaultInitialState: State { State(title: "Lasso ❤️ SwiftUI", sections: [.screens, .flows]) }
+}
+
+final class AppCatalogStore: LassoStore<AppCatalogScreen> {
+    
+    override func handleAction(_ action: Action) {
+        dispatchOutput(action)
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/AppCatalog/AppCatalogScreen/AppCatalogView.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/AppCatalog/AppCatalogScreen/AppCatalogView.swift
@@ -1,0 +1,67 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  AppCatalogView.swift
+//
+//  Created by Steven Grosmark on 03/23/2021.
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import SwiftUI
+import Lasso
+
+struct AppCatalogView: View {
+    
+    @ObservedObject private(set) var store: AppCatalogScreen.ViewStore
+    
+    var body: some View {
+        VStack {
+            Text(store.state.title).padding()
+            List {
+                ForEach(store.state.sections) { section in
+                    Section(header: CatalogSectionHeader(section: section)) {
+                        ForEach(section.items) { item in
+                            NavigationRow(item.title, target: store, action: item)
+                        }
+                    }
+                }
+            }.listStyle(GroupedListStyle())
+        }
+        .navigationBarTitle("Samples")
+    }
+}
+
+private struct CatalogSectionHeader: View {
+    let section: AppCatalogScreen.Section
+    var body: some View {
+        HStack {
+            Image(systemName: section.systemImage)
+            Text(section.title)
+        }
+    }
+}
+
+extension AppCatalogScreen.Section {
+    
+    fileprivate var systemImage: String {
+        switch self {
+        case .screens: return "doc"
+        case .flows: return "doc.on.doc"
+        }
+    }
+}
+
+struct CatalogView_Previews: PreviewProvider {
+    static var previews: some View {
+        let store = AppCatalogStore(with: AppCatalogScreen.defaultInitialState)
+        AppCatalogView(store: store.asViewStore())
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/AppDelegate.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/AppDelegate.swift
@@ -1,0 +1,40 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  AppDelegate.swift
+//
+//  Created by Steven Grosmark on 03/23/2021.
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import UIKit
+import Lasso
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    
+    var window: UIWindow?
+    
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        self.window = window
+        window.backgroundColor = .white
+        
+        AppCatalogFlow().start(with: root(of: window).withNavigationEmbedding())
+        
+        window.makeKeyAndVisible()
+        
+        return true
+    }
+    
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/Contents.json
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/buttonBackground.colorset/Contents.json
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/buttonBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.969",
+          "green" : "0.503",
+          "red" : "0.584"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.969",
+          "green" : "0.503",
+          "red" : "0.584"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/buttonDisabledBackground.colorset/Contents.json
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/buttonDisabledBackground.colorset/Contents.json
@@ -1,0 +1,34 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "extended-gray",
+        "components" : {
+          "alpha" : "1.000",
+          "white" : "0.572"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "extended-gray",
+        "components" : {
+          "alpha" : "1.000",
+          "white" : "0.572"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/buttonForeground.colorset/Contents.json
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/buttonForeground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/buttonPressedBackground.colorset/Contents.json
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Assets.xcassets/buttonPressedBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.745",
+          "green" : "0.497",
+          "red" : "0.497"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.745",
+          "green" : "0.497",
+          "red" : "0.497"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Components/ActivityIndicator.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Components/ActivityIndicator.swift
@@ -1,0 +1,49 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  ActivityIndicator.swift
+//
+//  Created by Steven Grosmark on 03/26/2021
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import UIKit
+import SwiftUI
+
+struct ActivityIndicator: View {
+    
+    @State var isAnimating: Bool = true
+    
+    var body: some View {
+        if #available(iOS 14.0, *) {
+            ProgressView().progressViewStyle(CircularProgressViewStyle())
+        }
+        else {
+            UIKitActivityIndicator(isAnimating: $isAnimating, style: .medium)
+        }
+    }
+    
+    private struct UIKitActivityIndicator: UIViewRepresentable {
+        
+        @Binding var isAnimating: Bool
+        let style: UIActivityIndicatorView.Style
+        
+        func makeUIView(context: UIViewRepresentableContext<UIKitActivityIndicator>) -> UIActivityIndicatorView {
+            let indicator = UIActivityIndicatorView(style: style)
+            indicator.hidesWhenStopped = false
+            return indicator
+        }
+        
+        func updateUIView(_ uiView: UIActivityIndicatorView, context: UIViewRepresentableContext<UIKitActivityIndicator>) {
+            isAnimating ? uiView.startAnimating() : uiView.stopAnimating()
+        }
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Components/NavigationRow.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Components/NavigationRow.swift
@@ -1,0 +1,75 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  NavigationRow.swift
+//
+//  Created by Steven Grosmark on 03/24/2021.
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import SwiftUI
+import Lasso
+
+/// A list item with a NavigationLink appearance, for dispatching a Lasso Action to a Store.
+struct NavigationRow<Label>: View where Label: View {
+    
+    private let action: () -> Void
+    private let label: () -> Label
+    
+    /// NavigationLink with a view builder
+    ///
+    /// ```
+    /// NavigationLink(store, action: .didTapItem(idOfItem)) {
+    ///   Image(systemName: "heart")
+    ///   Text("Item of the Heart")
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - target: The `ViewStore` to receive the `Action`.
+    ///   - action: The `Action` to dispatch to the `ViewStore` when the item is tapped.
+    ///   - label: The row's content.
+    public init<Target: ActionDispatchable>(_ target: Target,
+                                            action: Target.Action,
+                                            @ViewBuilder label: @escaping () -> Label) {
+        self.action = { target.dispatchAction(action) }
+        self.label = label
+    }
+    
+    /// NavigationLink with test content
+    ///
+    /// ```
+    /// NavigationLink("An Item", target: store, action: .didTapItem(idOfItem))
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - label: The row's string label.
+    ///   - target: The `ViewStore` to receive the `Action`.
+    ///   - action: The `Action` to dispatch to the `ViewStore` when the item is tapped.
+    public init<Target: ActionDispatchable>(_ label: String,
+                                            target: Target,
+                                            action: Target.Action) where Label == Text {
+        self.action = { target.dispatchAction(action) }
+        self.label = { Text(label) }
+    }
+    
+    public var body: some View {
+        Button(action: action) {
+            HStack {
+                label()
+                Spacer()
+                Image(systemName: "chevron.right").opacity(0.5)
+            }
+        }
+        .buttonStyle(RowStyle())
+    }
+    
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Info.plist
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/LaunchScreen.storyboard
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/LaunchScreen.storyboard
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
+                                <rect key="frame" x="0.0" y="626.5" width="375" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lasso-SwiftUI" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                                <rect key="frame" x="0.0" y="202" width="375" height="43"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="centerX" secondItem="obG-Y5-kRd" secondAttribute="centerX" id="5cz-MP-9tL"/>
+                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="centerX" secondItem="GJd-Yh-RWb" secondAttribute="centerX" id="Q3B-4B-g5h"/>
+                            <constraint firstItem="obG-Y5-kRd" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" constant="20" symbolic="YES" id="SfN-ll-jLj"/>
+                            <constraint firstAttribute="bottom" secondItem="obG-Y5-kRd" secondAttribute="bottom" constant="20" id="Y44-ml-fuU"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="bottom" multiplier="1/3" constant="1" id="moa-c2-u7t"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" constant="20" symbolic="YES" id="x7j-FC-K8j"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Flows/WelcomeOnboarding/WelcomeMessage.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Flows/WelcomeOnboarding/WelcomeMessage.swift
@@ -1,0 +1,43 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  WelcomeMessage.swift
+//
+//  Created by Steven Grosmark on 03/25/2021
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import UIKit
+import SwiftUI
+import Lasso
+
+enum WelcomeMessage: PassthroughScreenModule {
+    
+    struct State: Equatable {
+        let text: String
+        
+        init(text: String = "") {
+            self.text = text
+        }
+    }
+    
+    enum Action: Equatable {
+        case didTapNext
+    }
+    typealias Output = Action
+    
+    static var defaultInitialState: State { State() }
+    
+    static func createScreen(with store: PassthroughStore<WelcomeMessage>) -> Screen {
+        let controller = WelcomeMessageView(store: store.asViewStore())
+        return Screen(store, controller)
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Flows/WelcomeOnboarding/WelcomeMessageView.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Flows/WelcomeOnboarding/WelcomeMessageView.swift
@@ -1,0 +1,50 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  WelcomeMessageView.swift
+//
+//  Created by Steven Grosmark on 03/25/2021
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import SwiftUI
+import Lasso
+
+struct WelcomeMessageView: View {
+    
+    @ObservedObject private var store: WelcomeMessage.ViewStore
+    
+    init(store: WelcomeMessage.ViewStore) {
+        self.store = store
+    }
+    
+    var body: some View {
+        VStack {
+            Spacer()
+            Text(store.state.text)
+                .font(.largeTitle)
+                .padding()
+            
+            Spacer()
+            Button("Next", target: store, action: .didTapNext)
+                .buttonStyle(PrimaryButtonStyle())
+        }
+        .padding()
+    }
+
+}
+
+struct WelcomeMessageView_Previews: PreviewProvider {
+    static var previews: some View {
+        let store = WelcomeMessage.ConcreteStore(with: WelcomeMessage.defaultInitialState)
+        WelcomeMessageView(store: store.asViewStore())
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Flows/WelcomeOnboarding/WelcomeOnboardingFlow.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Flows/WelcomeOnboarding/WelcomeOnboardingFlow.swift
@@ -1,0 +1,54 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  WelcomeOnboardingFlow.swift
+//
+//  Created by Steven Grosmark on 03/25/2021
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import UIKit
+import Lasso
+
+enum WelcomeOnboarding: NavigationFlowModule {
+    enum Output: Equatable {
+        case didFinish
+    }
+}
+
+class WelcomeOnboardingFlow: Flow<WelcomeOnboarding> {
+    
+    override func createInitialController() -> UIViewController {
+        assembleFirstScreen()
+            .controller
+    }
+    
+    private func assembleFirstScreen() -> WelcomeMessage.Screen {
+        WelcomeMessage
+            .createScreen(with: WelcomeMessage.State(text: "Welcome!"))
+            .observeOutput { [weak self] output in
+                if output == .didTapNext {
+                    self?.assembleFinalScreen().place(with: self?.nextPushedInFlow)
+                }
+            }
+    }
+    
+    private func assembleFinalScreen() -> WelcomeMessage.Screen {
+        WelcomeMessage
+            .createScreen(with: WelcomeMessage.State(text: "Have fun!"))
+            .observeOutput { [weak self] output in
+                if output == .didTapNext {
+                    self?.dispatchOutput(.didFinish)
+                }
+            }
+    }
+    
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/Login/Login.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/Login/Login.swift
@@ -1,0 +1,50 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  Login.swift
+//
+//  Created by Steven Grosmark on 03/26/2021
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import UIKit
+import SwiftUI
+import Lasso
+
+enum Login: ScreenModule {
+    
+    enum Action: Equatable {
+        case didEditUsername(String)
+        case didEditPassword(String)
+        case didTapLogin
+    }
+    
+    enum Output: Equatable {
+        case didLogin
+    }
+    
+    struct State: Equatable {
+        var username: String = ""
+        var password: String = ""
+        var canLogin: Bool = false
+        var error: String?
+        var phase: Phase = .idle
+        
+        enum Phase { case idle, busy }
+    }
+    
+    static var defaultInitialState: State { return State() }
+    
+    static func createScreen(with store: LoginStore) -> Screen {
+        let view = LoginView(store: store.asViewStore())
+        return Screen(store, view)
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/Login/LoginService.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/Login/LoginService.swift
@@ -1,0 +1,46 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  LoginService.swift
+//
+//  Created by Steven Grosmark on 03/26/2021
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import Foundation
+import Lasso
+
+protocol LoginServiceProtocol {
+    func login(_ username: String, password: String, completion: @escaping (Result<Void, Error>) -> Void)
+}
+
+struct LoginService: LoginServiceProtocol {
+    
+    @Mockable static private(set) var shared: LoginServiceProtocol = LoginService()
+    
+    enum LoginError: Error {
+        case invalidCredentials
+    }
+    
+    func login(_ username: String, password: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            let isLoggedIn = Int.random(in: 0...100) < LoginService.successRate
+            switch isLoggedIn {
+            case true: completion(.success(()))
+            case false: completion(.failure(LoginError.invalidCredentials))
+            }
+        }
+    }
+    
+    /// Chance of success, from 0 through 100 percent
+    static var successRate: Int = 50
+    
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/Login/LoginStore.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/Login/LoginStore.swift
@@ -1,0 +1,78 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  LoginStore.swift
+//
+//  Created by Steven Grosmark on 03/26/2021
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import Foundation
+import Lasso
+
+final class LoginStore: LassoStore<Login> {
+    
+    override func handleAction(_ action: Action) {
+        switch action {
+        
+        case .didEditUsername(let username):
+            update { state in
+                state.username = username
+                state.canLogin = !username.isEmpty && !state.password.isEmpty
+            }
+            
+        case .didEditPassword(let password):
+            update { state in
+                state.password = password
+                state.canLogin = !state.username.isEmpty && !password.isEmpty
+            }
+            
+        case .didTapLogin:
+            login()
+        }
+    }
+    
+    private func login() {
+        guard state.phase == .idle else { return }
+        guard state.canLogin else {
+            update { state in
+                state.error = "Please enter your username and password"
+            }
+            return
+        }
+        
+        update { state in
+            state.phase = .busy
+            state.error = nil
+            state.canLogin = false
+        }
+        
+        LoginService.shared.login(state.username, password: state.password) { [weak self] result in
+            guard let self = self else { return }
+            
+            switch result {
+            
+            case .success:
+                self.update { state in
+                    state.phase = .idle
+                }
+                self.dispatchOutput(.didLogin)
+                
+            case .failure:
+                self.update { state in
+                    state.phase = .idle
+                    state.canLogin = !state.username.isEmpty && !state.password.isEmpty
+                    state.error = "Invalid login"
+                }
+            }
+        }
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/Login/LoginView.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/Login/LoginView.swift
@@ -1,0 +1,84 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  LoginView.swift
+//
+//  Created by Steven Grosmark on 03/26/2021
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import SwiftUI
+import Lasso
+
+extension LassoView where Self: View {
+}
+
+struct LoginView: View, LassoView {
+    
+    @ObservedObject var store: Login.ViewStore
+    
+    init(store: Login.ViewStore) {
+        self.store = store
+    }
+    
+    var body: some View {
+        VStack {
+            Text("Login")
+                .font(.largeTitle)
+                .padding()
+            
+            TextField(
+                "username",
+                boundTo: store,
+                text: \.username,
+                action: Login.Action.didEditUsername
+            )
+            .disableAutocorrection(true)
+            .autocapitalization(.none)
+            
+            SecureField(
+                "password",
+                text: store.binding(\.password, action: Login.Action.didEditPassword)
+            )
+            .disableAutocorrection(true)
+            .autocapitalization(.none)
+            
+            Button("Login", target: store, action: .didTapLogin)
+                .disabled(!store.state.canLogin)
+                .padding(EdgeInsets(top: 40, leading: 0, bottom: 0, trailing: 0))
+            
+            VStack {
+                Color.clear.frame(height: 10) // keeps the VStack from collapsing
+                if let error = state.error {
+                    Text(error)
+                        .foregroundColor(.red)
+                }
+                if state.phase == .busy {
+                    ActivityIndicator()
+                }
+            }
+            .frame(height: 100, alignment: .top)
+        }
+        .frame(alignment: .top)
+        .textFieldStyle(PrimaryTextFieldStyle())
+        .buttonStyle(PrimaryButtonStyle())
+        .padding()
+        .frame(maxWidth: 300)
+    }
+    
+}
+
+struct LoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        let store = LoginStore(with: Login.defaultInitialState)
+        LoginView(store: store.asViewStore())
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/SimpleCounter/SimpleCounter.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/SimpleCounter/SimpleCounter.swift
@@ -1,0 +1,39 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  SimpleCounter.swift
+//
+//  Created by Steven Grosmark on 03/24/2021.
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import UIKit
+import SwiftUI
+import Lasso
+
+enum SimpleCounter: ScreenModule {
+    
+    enum Action: Equatable {
+        case didTapIncrement
+        case didTapDecrement
+    }
+    
+    struct State: Equatable {
+        var count: Int = 0
+    }
+    
+    static var defaultInitialState: State { return State() }
+    
+    static func createScreen(with store: SimpleCounterStore) -> Screen {
+        let view = SimpleCounterView(store: store.asViewStore())
+        return Screen(store, view)
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/SimpleCounter/SimpleCounterStore.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/SimpleCounter/SimpleCounterStore.swift
@@ -1,0 +1,37 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  SimpleCounterStore.swift
+//
+//  Created by Steven Grosmark on 03/25/2021.
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import Foundation
+import Lasso
+
+final class SimpleCounterStore: LassoStore<SimpleCounter> {
+    
+    override func handleAction(_ action: Action) {
+        switch action {
+        
+        case .didTapIncrement:
+            update { state in
+                state.count += 1
+            }
+            
+        case .didTapDecrement:
+            update { state in
+                state.count = max(state.count - 1, 0)
+            }
+        }
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/SimpleCounter/SimpleCounterView.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Samples/Screens/SimpleCounter/SimpleCounterView.swift
@@ -1,0 +1,59 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  SimpleCounterView.swift
+//
+//  Created by Steven Grosmark on 03/25/2021.
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import SwiftUI
+import Lasso
+
+struct SimpleCounterView: View {
+    
+    @ObservedObject private var store: SimpleCounter.ViewStore
+    
+    init(store: SimpleCounter.ViewStore) {
+        self.store = store
+    }
+    
+    var body: some View {
+        VStack {
+            Text("How many?")
+                .padding()
+            
+            Text("\(store.state.count)")
+                .font(.largeTitle)
+                .scaledToFill()
+                .frame(width: 260, height: 200)
+                .background(Color.gray.opacity(0.25))
+                .cornerRadius(11)
+                .padding()
+            
+            HStack(spacing: 20) {
+                Button("-1", target: store, action: .didTapDecrement)
+                Button("+1", target: store, action: .didTapIncrement)
+            }
+            .frame(width: 260)
+            .buttonStyle(PrimaryButtonStyle())
+        }
+        .padding()
+    }
+    
+}
+
+struct SimpleCounterView_Previews: PreviewProvider {
+    static var previews: some View {
+        let store = SimpleCounterStore(with: SimpleCounter.defaultInitialState)
+        SimpleCounterView(store: store.asViewStore())
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Style/ButtonStyle+App.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Style/ButtonStyle+App.swift
@@ -1,0 +1,99 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  ButtonStyle+App.swift
+//
+//  Created by Steven Grosmark on 03/24/2021.
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import SwiftUI
+
+struct RowStyle: ButtonStyle {
+    func makeBody(configuration: Self.Configuration) -> some View {
+        configuration.label
+            .frame(maxWidth: .infinity)
+            .background(
+                (configuration.isPressed ? Color(white: 0.9, opacity: 1.0) : Color.white)
+                    .padding(EdgeInsets(top: -12, leading: -20, bottom: -12, trailing: -20)) // magic number alert!
+            )
+        
+    }
+}
+
+struct PrimaryButtonStyle: ButtonStyle {
+    
+    private let maxWidth: CGFloat
+    private let innerPadding: EdgeInsets
+    
+    init(maxWidth: CGFloat = 320, innerPadding: EdgeInsets = EdgeInsets(10)) {
+        self.maxWidth = maxWidth
+        self.innerPadding = innerPadding
+    }
+    
+    func makeBody(configuration: Self.Configuration) -> some View {
+        MyButton(configuration: configuration, maxWidth: maxWidth, innerPadding: innerPadding)
+    }
+    
+    private struct MyButton: View {
+        let configuration: ButtonStyle.Configuration
+        let maxWidth: CGFloat
+        let innerPadding: EdgeInsets
+        @Environment(\.isEnabled) private var isEnabled: Bool
+        var body: some View {
+            configuration.label
+                .font(.headline)
+                .padding(innerPadding)
+                .frame(maxWidth: maxWidth)
+                .multilineTextAlignment(.center)
+                .foregroundColor(Color.buttonForeground)
+                .background(
+                    background(isEnabled, configuration.isPressed)
+                        .cornerRadius(5)
+                )
+        }
+        
+        private func background(_ isEnabled: Bool, _ isPressed: Bool) -> Color {
+            if !isEnabled {
+                return Color.buttonDisabledBackground
+            }
+            return isPressed ? Color.buttonPressedBackground : Color.buttonBackground
+        }
+    }
+}
+
+struct PrimaryButton_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            Text("buttons")
+            
+            Color.blue.frame(width: 200, height: 4, alignment: .center)
+            Button("Primary Button (200pt)", action: { })
+                .buttonStyle(PrimaryButtonStyle(maxWidth: 200))
+            
+            Color.blue.frame(width: 320, height: 4, alignment: .center)
+            Button("Primary Button Primary Button Primary Button Primary Button (default maxWidth)", action: { })
+                .buttonStyle(PrimaryButtonStyle())
+            
+            Button("Primary Button Primary Button Primary Button Primary Button (∞)", action: { })
+                .buttonStyle(PrimaryButtonStyle(maxWidth: .infinity))
+            
+            Color.blue.frame(width: 200, height: 4, alignment: .center)
+            Button("Disabled Primary Button", action: { })
+                .disabled(true)
+                .buttonStyle(PrimaryButtonStyle())
+        }
+//        .previewLayout(.fixed(width: 320, height: 480))
+//        .previewDevice("iPhone SE (2nd generation)")
+//        .previewDevice("iPhone 8")
+//        .previewDevice("iPhone 12 Pro Max")
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Style/Color+Style.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Style/Color+Style.swift
@@ -1,0 +1,27 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  Color+Style.swift
+//
+//  Created by Steven Grosmark on 03/24/2021.
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import SwiftUI
+
+extension Color {
+    
+    static let buttonForeground = Color("buttonForeground")
+    static let buttonBackground = Color("buttonBackground")
+    static let buttonPressedBackground = Color("buttonPressedBackground")
+    static let buttonDisabledBackground = Color("buttonDisabledBackground")
+    
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Style/TextFieldStyle+App.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Style/TextFieldStyle+App.swift
@@ -1,0 +1,48 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  TextFieldStyle+App.swift
+//
+//  Created by Steven Grosmark on 03/26/2021
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import SwiftUI
+
+struct PrimaryTextFieldStyle: TextFieldStyle {
+    func _body(configuration: TextField<_Label>) -> some View {
+        configuration
+            .padding(EdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0))
+            .overlay(
+                Color.gray.frame(height: 2),
+                alignment: .bottom
+            )
+    }
+}
+
+struct PrimaryTextField_Previews: PreviewProvider {
+    
+    static var previews: some View { Preview() }
+    
+    struct Preview: View {
+        @State var someText: String = ""
+        var body: some View {
+            VStack {
+                Text("text fields")
+                
+                TextField("Enter text", text: $someText)
+                    .textFieldStyle(PrimaryTextFieldStyle())
+            }
+            .frame(maxWidth: 300)
+            .padding()
+        }
+    }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Utilities/EdgeInsets+Helpers.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Utilities/EdgeInsets+Helpers.swift
@@ -1,0 +1,28 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  EdgeInsets+Zero.swift
+//
+//  Created by Steven Grosmark on 03/24/2021.
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import SwiftUI
+
+extension EdgeInsets {
+    
+    static let zero: EdgeInsets = EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+    
+    public init(_ value: CGFloat) {
+        self.init(top: value, leading: value, bottom: value, trailing: value)
+    }
+    
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Utilities/SelfIdentifiable.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Utilities/SelfIdentifiable.swift
@@ -1,0 +1,27 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  SelfIdentifiable.swift
+//
+//  Created by Steven Grosmark on 03/23/2021.
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import Foundation
+
+/// `Identifiable` that uses `self` for the `id` value.  Useful for enums w/o associated values.
+protocol SelfIdentifiable: Identifiable {
+    var id: Self { get }
+}
+
+extension SelfIdentifiable where Self: Hashable {
+    var id: Self { self }
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUI/Utilities/String+CamelCase.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUI/Utilities/String+CamelCase.swift
@@ -1,0 +1,66 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  String+CamelCase.swift
+//
+//  Created by Steven Grosmark on 03/25/2021
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import Foundation
+
+protocol TitleConvertible {
+    var title: String { get }
+}
+
+extension TitleConvertible {
+    var title: String { "\(self)".convertCamelCaseToTitleCase() }
+}
+
+extension String {
+    
+    func convertCamelCaseToTitleCase() -> String {
+        var wasUppercase = false
+        var pending = ""
+        var result = self.reduce(into: "") { result, ch in
+            switch (ch.isUppercase, wasUppercase) {
+            
+            case (false, true):
+                if !result.isEmpty, !result.hasSuffix(" ") {
+                    result.append(" ")
+                }
+                result.append(pending)
+                fallthrough
+                
+            case (false, false):
+                result.append(ch)
+                wasUppercase = false
+                
+            case (true, true):
+                result.append(pending)
+                pending = ch.lowercased()
+                wasUppercase = true
+                
+            case (true, false):
+                if !result.isEmpty, !result.hasSuffix(" ") {
+                    result.append(" ")
+                }
+                pending = ch.lowercased()
+                wasUppercase = true
+            }
+        }
+        if wasUppercase {
+            result.append(pending)
+        }
+        return result.first?.uppercased().appending(result.dropFirst()) ?? ""
+    }
+    
+}

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUITests/Info.plist
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Example/Lasso-SwiftUI/Lasso-SwiftUITests/Lasso_SwiftUITests.swift
+++ b/Example/Lasso-SwiftUI/Lasso-SwiftUITests/Lasso_SwiftUITests.swift
@@ -1,0 +1,27 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  Lasso_SwiftUITests.swift
+//
+//  Created by Steven Grosmark on 03/23/2021.
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import XCTest
+@testable import Lasso_SwiftUI
+
+class LassoSwiftUITests: XCTestCase {
+
+    func testExample() throws {
+        XCTAssertTrue(true)
+    }
+
+}

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,8 +2,8 @@ PODS:
   - Lasso (1.2.0)
   - LassoTestUtilities (1.2.0):
     - Lasso
-  - SwiftLint (0.42.0)
-  - WWLayout (0.7.1)
+  - SwiftLint (0.43.1)
+  - WWLayout (0.8.0)
 
 DEPENDENCIES:
   - Lasso (from `../`)
@@ -25,8 +25,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Lasso: a9dfd09db3d5e9fd2c91f9bad270f6693c2605a5
   LassoTestUtilities: 6823a25d939bf7073143b5766415cfd3d2f2b75c
-  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
-  WWLayout: cf5e0def7f6c05e929f3660d3c9cdc0e7e733d0b
+  SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
+  WWLayout: 78d97792bdbf2ac8931ad31961e24218005a36ef
 
 PODFILE CHECKSUM: 41ab14c5f90b23266516b00a66a4869c4c1a18b9
 

--- a/Sources/Lasso/SwiftUI+Lasso/SwiftUI+Bindings.swift
+++ b/Sources/Lasso/SwiftUI+Lasso/SwiftUI+Bindings.swift
@@ -1,0 +1,76 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  SwiftUI+Bindings.swift
+//
+//  Created by Steven Grosmark on 03/26/2021
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+#if canImport(SwiftUI)
+import SwiftUI
+import Combine
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension AnyViewStore {
+    
+    public func binding<T>(_ keyPath: WritableKeyPath<ViewState, T>,
+                           action: @escaping(T) -> ViewAction) -> Binding<T> {
+        return Binding(get: { self.state[keyPath: keyPath] },
+                       set: { value in self.dispatchAction(action(value)) })
+    }
+    
+    public func binding<SourceValue, BoundValue>(_ keyPath: WritableKeyPath<ViewState, SourceValue>,
+                                                 value: @escaping(SourceValue) -> BoundValue,
+                                                 action: @escaping(BoundValue) -> ViewAction) -> Binding<BoundValue> {
+        return Binding(get: { value(self.state[keyPath: keyPath]) },
+                       set: { value in self.dispatchAction(action(value)) })
+    }
+    
+}
+
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+extension Button {
+    
+    public init<Target: ActionDispatchable>(_ target: Target, action: Target.Action, label: () -> Label) {
+        self.init(action: {
+            target.dispatchAction(action)
+        }, label: label)
+    }
+    
+    public init<Target: ActionDispatchable>(_ label: String, target: Target, action: Target.Action) where Label == Text {
+        self.init(
+            action: { target.dispatchAction(action) },
+            label: { Text(label) }
+        )
+    }
+    
+}
+
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+extension TextField where Label == Text {
+    
+    public init<S, State, Action>(
+        _ title: S,
+        boundTo store: AnyViewStore<State, Action>,
+        text: WritableKeyPath<State, String>,
+        action: @escaping (String) -> Action,
+        onEditingChanged: @escaping (Bool) -> Void = { _ in },
+        onCommit: @escaping () -> Void = {}
+    ) where S : StringProtocol {
+        self.init(title,
+                  text: store.binding(text, action: action),
+                  onEditingChanged: onEditingChanged,
+                  onCommit: onCommit)
+    }
+}
+
+#endif

--- a/Sources/Lasso/SwiftUI+Lasso/SwiftUI+Lasso.swift
+++ b/Sources/Lasso/SwiftUI+Lasso/SwiftUI+Lasso.swift
@@ -1,0 +1,33 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  SwiftUI+Lasso.swift
+//
+//  Created by Steven Grosmark on 03/20/21
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2021 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+#if canImport(SwiftUI)
+import SwiftUI
+import Combine
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension AnyScreen {
+    
+    public init<S: AbstractStore, Content>(_ store: S, _ view: Content)
+    where Content: View, S.State == State, S.Action == Action, S.Output == Output {
+        self.store = store.asAnyStore()
+        self.controller = UIHostingController(rootView: view)
+        self.controller.holdReference(to: self.store)
+    }
+}
+
+#endif


### PR DESCRIPTION
Issue https://github.com/ww-tech/lasso/issues/32

## Describe your changes

More refined proof-of-concept addition of SwiftUI to Lasso.

Key features of this approach:
- Extend `AnyViewStore` so it can be directly usable in a SwiftUI `View`
   - When SwiftUI is available, `ObservableObject` conformance is added, so `State` updates automatically trigger a refresh of the `View`
   - Added `binding` functions for two-way bindings to state values
- Add new version of `Screen.init` that accepts a `View` instead of a `UIViewController`
   - The `View` ir wrapped in a `UIHostingViewController` to work with the rest of Lasso

