### PR TITLE
Extend the default timeout

### DIFF
--- a/Example/LassoTestUtilities_Tests/AssertionTimeoutTests.swift
+++ b/Example/LassoTestUtilities_Tests/AssertionTimeoutTests.swift
@@ -42,7 +42,7 @@ class AssertionTimeoutDefaultTests: XCTestCase {
                                 Thread.sleep(forTimeInterval: 5.5)
                             }
                             DispatchQueue.main.async {
-                                Thread.sleep(forTimeInterval: 0.1)
+                                Thread.sleep(forTimeInterval: 1.1)
                             }
                             nav.viewControllers = [vc]
                         },

--- a/Example/LassoTestUtilities_Tests/AssertionTimeoutTests.swift
+++ b/Example/LassoTestUtilities_Tests/AssertionTimeoutTests.swift
@@ -21,7 +21,7 @@ import XCTest
 class AssertionTimeoutDefaultTests: XCTestCase {
     
     func test_default() throws {
-        XCTAssertEqual(lassoAssertionTimeout, 1)
+        XCTAssertEqual(lassoAssertionTimeout, 5)
         
         // given
         let window = UIWindow()
@@ -39,7 +39,7 @@ class AssertionTimeoutDefaultTests: XCTestCase {
                         of: nav,
                         when: {
                             DispatchQueue.main.async {
-                                Thread.sleep(forTimeInterval: 1.5)
+                                Thread.sleep(forTimeInterval: 5.5)
                             }
                             DispatchQueue.main.async {
                                 Thread.sleep(forTimeInterval: 0.1)

--- a/Sources/LassoTestUtilities/ControllerLifecycle.swift
+++ b/Sources/LassoTestUtilities/ControllerLifecycle.swift
@@ -42,7 +42,7 @@ extension XCTestCase {
         if let override = self as? AssertionTimeoutOverride {
             return override.defaultLassoAssertionTimeout
         }
-        return 1
+        return 5
     }
 
     /// Generalized utility for controller lifecycle hooks with respect to view controller hierarchy events.


### PR DESCRIPTION
## Describe your changes

We're getting too many main queue exhaustion failures in CI with the 1 second timeout.  Extending it to 5 seconds, understanding that failing tests will take longer to discover.