### PR TITLE
Fix documentation typos and markdown issues

### DIFF
--- a/docs/Lasso-Introduction-part1.md
+++ b/docs/Lasso-Introduction-part1.md
@@ -37,6 +37,7 @@ A `View` isn't a formal type in Lasso, but we do talk about them a lot.  When we
 Drawing this up in a diagram allows us to see how these types work together:
 
 <p align="center"><img src="images/screen.svg" style="width: 100%; max-width: 460px;" /></p>
+
 You should notice what looks like a **unidirectional data flow**.  The `View` translates user interactions into `Action` messages, which are sent to the `Store`.  The `Store` processes the `Action` messages and updates the `State`.  Changes to the `State` are sent back to the `View` as they happen.
 
 ### Building a login screen

--- a/docs/declaring-types-notes.md
+++ b/docs/declaring-types-notes.md
@@ -64,7 +64,7 @@ Note that it's quite common to create your own versions of `createScreen`, to al
 
 ```swift
 public static func createScreen(username: String) -> Screen {
-  let initialState = LoginScreenModule.State(username: "Billie")
+  let initialState = LoginScreenModule.State(username: username)
   return createScreen(with: initialState)
 }
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -59,7 +59,7 @@ enum MyModule: ScreenModule {
       var description: String {
         switch self {
           case .badInput: return "invalid input"
-          case .unknown: return "unknow error"
+          case .unknown: return "unknown error"
         }
       }
     }
@@ -101,7 +101,7 @@ extension MyModule.State.Error {
   var description: String {
     switch self {
       case .badInput: return "invalid input"
-      case .unknown: return "unknow error"
+      case .unknown: return "unknown error"
     }
   }
   


### PR DESCRIPTION
This pull request fixes:
- some minor documentation typos: `"unknow error"` --> `"unknown error"`
- documentation markdown issues (fixed by adding missing newline)
- documentation: `createScreen` code example issue (fixed to use the provided parameter value instead of hardcoded string value)