### PR TITLE
Handle setUpWithError in FlowTestCase

### DIFF
--- a/Example/Lasso.xcodeproj/project.pbxproj
+++ b/Example/Lasso.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		B094CBCD23494C60004C5CBE /* CounterStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B094CBCC23494C60004C5CBE /* CounterStoreTests.swift */; };
 		B094CBD0234951C8004C5CBE /* SignupIntroStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B094CBCF234951C8004C5CBE /* SignupIntroStoreTests.swift */; };
 		B094CBD2234952A1004C5CBE /* SignupFormStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B094CBD1234952A1004C5CBE /* SignupFormStoreTests.swift */; };
+		B0B2007027F73F8A00732F47 /* FowTestCaseSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B2006E27F73F5800732F47 /* FowTestCaseSetupTests.swift */; };
 		B0B23544260CFDC000F1EB2F /* Compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B23543260CFDC000F1EB2F /* Compatibility.swift */; };
 		B0C37243229C0FAF00FB214D /* RandomItemFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C37242229C0FAF00FB214D /* RandomItemFlow.swift */; };
 		E207AAE322F99F8B00D58979 /* SearchAndTrackFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E207AAE222F99F8A00D58979 /* SearchAndTrackFlow.swift */; };
@@ -186,6 +187,7 @@
 		B094CBCC23494C60004C5CBE /* CounterStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterStoreTests.swift; sourceTree = "<group>"; };
 		B094CBCF234951C8004C5CBE /* SignupIntroStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupIntroStoreTests.swift; sourceTree = "<group>"; };
 		B094CBD1234952A1004C5CBE /* SignupFormStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupFormStoreTests.swift; sourceTree = "<group>"; };
+		B0B2006E27F73F5800732F47 /* FowTestCaseSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FowTestCaseSetupTests.swift; sourceTree = "<group>"; };
 		B0B23543260CFDC000F1EB2F /* Compatibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Compatibility.swift; sourceTree = "<group>"; };
 		B0C37242229C0FAF00FB214D /* RandomItemFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomItemFlow.swift; sourceTree = "<group>"; };
 		D2BCE54DB43C58C9997169C3 /* Pods-Lasso_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Lasso_Example.debug.xcconfig"; path = "Target Support Files/Pods-Lasso_Example/Pods-Lasso_Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -543,6 +545,7 @@
 				E25C6E4C23195C450091BC72 /* ModalTestingTests+FullScreen.swift */,
 				E25C6E5023195DDA0091BC72 /* ModalTestingTests+SystemBehavior.swift */,
 				E2F4BDC722FC43E6003423CE /* NavigationTestingTests.swift */,
+				B0B2006E27F73F5800732F47 /* FowTestCaseSetupTests.swift */,
 				E2FD5A9F232694600008DE77 /* ValueDiffingTests.swift */,
 				79CE63E223F2F854003FFBF4 /* VerboseLoggingTests.swift */,
 				E207AB0A22F9AE3400D58979 /* Info.plist */,
@@ -1024,6 +1027,7 @@
 				E2FD5AA0232694600008DE77 /* ValueDiffingTests.swift in Sources */,
 				7932796023A1448200654D8A /* MockableExtensionTests.swift in Sources */,
 				E25C6E5123195DDA0091BC72 /* ModalTestingTests+SystemBehavior.swift in Sources */,
+				B0B2007027F73F8A00732F47 /* FowTestCaseSetupTests.swift in Sources */,
 				79CE63E323F2F854003FFBF4 /* VerboseLoggingTests.swift in Sources */,
 				E25C6E4D23195C450091BC72 /* ModalTestingTests+FullScreen.swift in Sources */,
 				E25C6E4F23195CF40091BC72 /* ModalTestingTests+AnyModalPresentationStyle.swift in Sources */,

--- a/Example/LassoTestUtilities_Tests/FowTestCaseSetupTests.swift
+++ b/Example/LassoTestUtilities_Tests/FowTestCaseSetupTests.swift
@@ -1,0 +1,108 @@
+//
+// ==----------------------------------------------------------------------== //
+//
+//  FowTestCaseSetupTests.swift
+//
+//  Created by Steven Grosmark on 04/01/2022
+//
+//
+//  This source file is part of the Lasso open source project
+//
+//     https://github.com/ww-tech/lasso
+//
+//  Copyright © 2019-2022 WW International, Inc.
+//
+// ==----------------------------------------------------------------------== //
+//
+
+import XCTest
+import UIKit
+@testable import LassoTestUtilities
+
+// MARK: - `setUp` / `tearDown` pair
+
+class FowTestCaseSetupTests: FlowTestCase {
+    
+    var windowInstance: ObjectIdentifier!
+    var navigationControllerInstance: ObjectIdentifier!
+    var rootControllerInstance: ObjectIdentifier!
+    
+    override func setUp() {
+        super.setUp()
+        XCTAssertNotNil(window)
+        XCTAssertNotNil(navigationController)
+        XCTAssertNotNil(rootController)
+        
+        windowInstance = ObjectIdentifier(window)
+        navigationControllerInstance = ObjectIdentifier(navigationController)
+        rootControllerInstance = ObjectIdentifier(rootController)
+    }
+    
+    override func tearDown() {
+        XCTAssertEqual(windowInstance, ObjectIdentifier(window))
+        XCTAssertEqual(navigationControllerInstance, ObjectIdentifier(navigationController))
+        XCTAssertEqual(rootControllerInstance, ObjectIdentifier(rootController))
+        
+        super.tearDown()
+    }
+    
+    /// Gratuitous test func needed to invoke `setUp` and `tearDown`
+    func test_setupAndTeardown() {
+        XCTAssertTrue(true)
+    }
+}
+
+// MARK: - `setUpWithError` / `tearDownWithError`
+
+#if compiler(>=5.2)
+class FowTestCaseSetupWithErrorTests: FlowTestCase {
+    
+    var windowInstance: ObjectIdentifier!
+    var navigationControllerInstance: ObjectIdentifier!
+    var rootControllerInstance: ObjectIdentifier!
+    
+    /// Called before `setUp`
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        XCTAssertNotNil(window)
+        XCTAssertNotNil(navigationController)
+        XCTAssertNotNil(rootController)
+        
+        windowInstance = ObjectIdentifier(window)
+        navigationControllerInstance = ObjectIdentifier(navigationController)
+        rootControllerInstance = ObjectIdentifier(rootController)
+    }
+    
+    /// Celled after `setUpWithError`
+    override func setUp() {
+        super.setUp()
+        
+        XCTAssertEqual(windowInstance, ObjectIdentifier(window))
+        XCTAssertEqual(navigationControllerInstance, ObjectIdentifier(navigationController))
+        XCTAssertEqual(rootControllerInstance, ObjectIdentifier(rootController))
+    }
+    
+    /// Called before `tearDownWithError`
+    override func tearDown() {
+        XCTAssertEqual(windowInstance, ObjectIdentifier(window))
+        XCTAssertEqual(navigationControllerInstance, ObjectIdentifier(navigationController))
+        XCTAssertEqual(rootControllerInstance, ObjectIdentifier(rootController))
+        
+        super.tearDown()
+    }
+    
+    /// Celled after `tearDown`
+    override func tearDownWithError() throws {
+        XCTAssertEqual(windowInstance, ObjectIdentifier(window))
+        XCTAssertEqual(navigationControllerInstance, ObjectIdentifier(navigationController))
+        XCTAssertEqual(rootControllerInstance, ObjectIdentifier(rootController))
+        
+        try super.tearDownWithError()
+    }
+    
+    /// Gratuitous test func needed to invoke `setUp` and `tearDown`
+    func test_setupAndTeardown() {
+        XCTAssertTrue(true)
+    }
+}
+#endif

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Lasso (1.2.1)
   - LassoTestUtilities (1.2.1):
     - Lasso
-  - SwiftLint (0.46.2)
+  - SwiftLint (0.47.0)
   - WWLayout (0.8.2)
 
 DEPENDENCIES:
@@ -25,9 +25,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Lasso: 638615c7e2c4232bb3fddee191d8417ac89a5a3a
   LassoTestUtilities: 5d59acc41c12a6b5fb52e174b5721702aa421480
-  SwiftLint: 6bc52a21f0fd44cab9aa2dc8e534fb9f5e3ec507
+  SwiftLint: d41cc46a2ae58ac6d9f26954bc89f1d72e71fdef
   WWLayout: 0ff533a6b9d0ae2ca2bdf91b6aefc04234b61f1b
 
 PODFILE CHECKSUM: 6b80e3b8efd66dc0c2560f83571e041ae1a60451
 
-COCOAPODS: 1.10.2
+COCOAPODS: 1.11.2

--- a/Sources/LassoTestUtilities/FlowTestCase.swift
+++ b/Sources/LassoTestUtilities/FlowTestCase.swift
@@ -19,9 +19,12 @@ import XCTest
 import UIKit
 
 /// Provides conveniences for Flow unit testing.
+///
 /// Key features:
 /// 1) a UIWindow which is made 'key and visible'. This is required for lifecycle hooks to work.
 /// 2) convenience controllers in the root of the window which cover the most common use cases
+///
+/// Does **NOT** support async versions of `setUp` and `tearDown`
 open class FlowTestCase: XCTestCase {
     
     public var window: UIWindow {
@@ -42,6 +45,7 @@ open class FlowTestCase: XCTestCase {
     private var _window: UIWindow!
     private var _navigationController: UINavigationController!
     private var _rootController: UIViewController!
+    private var _didTearDown: Bool = false
     
     // https://developer.apple.com/documentation/xctest/xctestcase/set_up_and_tear_down_state_in_your_tests
     //
@@ -54,11 +58,19 @@ open class FlowTestCase: XCTestCase {
     // We want to set up the FlowTestCase as early as possible so that
     // subclasses can start to access the helpers and make assertions in
     // their setUp funcs.
-    // Since subclasses _might_ want to use the async version of setUp,
-    // and the @available runtime check won't work (needs a compile time check),
-    // we can't override the various set up funcs to guarantee initialization.
-    // Instead, we'll use lazy initialization of the window and controller properties.
-    //
+    
+    #if compiler(>=5.2)
+    open override func setUpWithError() throws {
+        try super.setUpWithError()
+        setUpFlowTestCase()
+    }
+    #endif
+    
+    open override func setUp() {
+        super.setUp()
+        setUpFlowTestCase()
+    }
+    
     // tearDown:
     // XCTest runs the teardown methods once after each test method completes, with
     //  tearDown() first (Xcode 7.5+),
@@ -68,8 +80,6 @@ open class FlowTestCase: XCTestCase {
     // We want to tear down the FlowTestCase as late as possible, since
     // subclasses _might_ depend on these values in their tearDown funcs
     // (Rarely done, but possible to use XCTest assertions in tearDown).
-    // Skipping the async version of tearDown because the @available runtime check
-    // is insufficient - it needs a compiler check.
     
     #if compiler(>=5.2)
     open override func tearDownWithError() throws {
@@ -85,7 +95,7 @@ open class FlowTestCase: XCTestCase {
     #endif
     
     private func setUpFlowTestCase() {
-        guard _window == nil else { return }
+        guard _window == nil, !_didTearDown else { return }
         _window = UIWindow()
         _window.makeKeyAndVisible()
         _rootController = UIViewController()
@@ -95,6 +105,7 @@ open class FlowTestCase: XCTestCase {
     }
     
     private func tearDownFlowTestCase() {
+        _didTearDown = true
         _window = nil
         _navigationController = nil
         _rootController = nil

--- a/Sources/LassoTestUtilities/FlowTestCase.swift
+++ b/Sources/LassoTestUtilities/FlowTestCase.swift
@@ -24,34 +24,80 @@ import UIKit
 /// 2) convenience controllers in the root of the window which cover the most common use cases
 open class FlowTestCase: XCTestCase {
     
-    public private(set) var window: UIWindow!
-    public private(set) var navigationController: UINavigationController!
-    public private(set) var rootController: UIViewController!
-    
-    open override func setUpWithError() throws {
-        try super.setUpWithError()
+    public var window: UIWindow {
         setUpFlowTestCase()
+        return _window
     }
     
-    open override func setUp() {
-        super.setUp()
+    public var navigationController: UINavigationController {
         setUpFlowTestCase()
+        return _navigationController
     }
+    
+    public var rootController: UIViewController {
+        setUpFlowTestCase()
+        return _rootController
+    }
+    
+    private var _window: UIWindow!
+    private var _navigationController: UINavigationController!
+    private var _rootController: UIViewController!
+    
+    // https://developer.apple.com/documentation/xctest/xctestcase/set_up_and_tear_down_state_in_your_tests
+    //
+    // setUp:
+    // XCTest runs the setup methods once before each test method starts:
+    //  setUp() async throws (Xcode 13+) first,
+    //  then setUpWithError() (Xcode 11.4+),
+    //  then setUp() (Xcode 7.5+).
+    //
+    // We want to set up the FlowTestCase as early as possible so that
+    // subclasses can start to access the helpers and make assertions in
+    // their setUp funcs.
+    // Since subclasses _might_ want to use the async version of setUp,
+    // and the @available runtime check won't work (needs a compile time check),
+    // we can't override the various set up funcs to guarantee initialization.
+    // Instead, we'll use lazy initialization of the window and controller properties.
+    //
+    // tearDown:
+    // XCTest runs the teardown methods once after each test method completes, with
+    //  tearDown() first (Xcode 7.5+),
+    //  then tearDownWithError() (Xcode 11.4+),
+    //  then tearDown() async throws (Xcode 13+).
+    //
+    // We want to tear down the FlowTestCase as late as possible, since
+    // subclasses _might_ depend on these values in their tearDown funcs
+    // (Rarely done, but possible to use XCTest assertions in tearDown).
+    // Skipping the async version of tearDown because the @available runtime check
+    // is insufficient - it needs a compiler check.
+    
+    #if compiler(>=5.2)
+    open override func tearDownWithError() throws {
+        tearDownFlowTestCase()
+        try super.tearDownWithError()
+    }
+    
+    #else
+    open override func tearDown() {
+        tearDownFlowTestCase()
+        super.tearDown()
+    }
+    #endif
     
     private func setUpFlowTestCase() {
-        guard window == nil else { return }
-        window = UIWindow()
-        window.makeKeyAndVisible()
-        rootController = UIViewController()
-        navigationController = UINavigationController(rootViewController: rootController)
-        window.rootViewController = navigationController
-        waitForEvents(in: window)
-        
-        addTeardownBlock { [weak self] in
-            self?.window = nil
-            self?.navigationController = nil
-            self?.rootController = nil
-        }
+        guard _window == nil else { return }
+        _window = UIWindow()
+        _window.makeKeyAndVisible()
+        _rootController = UIViewController()
+        _navigationController = UINavigationController(rootViewController: _rootController)
+        _window.rootViewController = _navigationController
+        waitForEvents(in: _window)
+    }
+    
+    private func tearDownFlowTestCase() {
+        _window = nil
+        _navigationController = nil
+        _rootController = nil
     }
     
 }

--- a/Sources/LassoTestUtilities/FlowTestCase.swift
+++ b/Sources/LassoTestUtilities/FlowTestCase.swift
@@ -28,21 +28,30 @@ open class FlowTestCase: XCTestCase {
     public private(set) var navigationController: UINavigationController!
     public private(set) var rootController: UIViewController!
     
+    open override func setUpWithError() throws {
+        try super.setUpWithError()
+        setUpFlowTestCase()
+    }
+    
     open override func setUp() {
         super.setUp()
+        setUpFlowTestCase()
+    }
+    
+    private func setUpFlowTestCase() {
+        guard window == nil else { return }
         window = UIWindow()
         window.makeKeyAndVisible()
         rootController = UIViewController()
         navigationController = UINavigationController(rootViewController: rootController)
         window.rootViewController = navigationController
         waitForEvents(in: window)
-    }
-    
-    open override func tearDown() {
-        window = nil
-        navigationController = nil
-        rootController = nil
-        super.tearDown()
+        
+        addTeardownBlock { [weak self] in
+            self?.window = nil
+            self?.navigationController = nil
+            self?.rootController = nil
+        }
     }
     
 }


### PR DESCRIPTION
## Describe your changes

`FlowTestCase` was only overriding `setUp`, so if a subclass was using `setUpWithError`, things would not get properly initialized.
