### PR TITLE
Make update closures Sendable

### DIFF
--- a/Sources/Lasso/Store/Store.swift
+++ b/Sources/Lasso/Store/Store.swift
@@ -89,7 +89,7 @@ open class LassoStore<Module: StoreModule>: ConcreteStore {
     
     // updates
     
-    public typealias Update<T> = (inout T) -> Void
+    public typealias Update<T> = @Sendable (inout T) -> Void
     
     public func update(_ update: @escaping Update<State> = { _ in return }) {
         updateState(using: update, apply: true)


### PR DESCRIPTION
On the road to Swift concurrency...

Makes all `update { state in ... }` closures `@Sendable`.
